### PR TITLE
update plugin id

### DIFF
--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -1,7 +1,7 @@
 {
     "type": "panel",
     "name": "Breadcrumb",
-    "id": "breadcrumb",
+    "id": "digiapulssi-breadcrumb-panel",
 
     "info": {
         "description": "Breadcrumb Panel for Grafana",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "type": "panel",
     "name": "Breadcrumb",
-    "id": "breadcrumb",
+    "id": "digiapulssi-breadcrumb-panel",
 
     "info": {
         "description": "Breadcrumb Panel for Grafana",


### PR DESCRIPTION
Hi,

My name is Daniel Lee and I help review plugins for Grafana. Thanks for submitting this! This is a really cool way to extend Grafana with breadcrumbs.

Technically it looks fine except for one small thing. The plugin id in the plugin.json file should follow the convention `<org name>-<name>-<type>` so in this case it should be `digiapulssi-breadcrumb-panel`.

If you want to publish a new version, then submit a PR to the [grafana-plugin-repository] (https://github.com/grafana/grafana-plugin-repository). There are two steps, update the version in the plugin.json (the plugin.json in the dist directory is the one that is parsed by Grafana) and then submit a PR with the commit hash.