### PR TITLE
Prevent the breadcrumbs from clearing query params

### DIFF
--- a/src/breadcrumb_ctrl.ts
+++ b/src/breadcrumb_ctrl.ts
@@ -141,7 +141,10 @@ class BreadcrumbCtrl extends PanelCtrl {
              sessionStorage.setItem("dashlist", JSON.stringify(this.dashboardList));
              // Parse modified breadcrumb and set it to url query params
              const parsedBreadcrumb = this.parseBreadcrumbForUrl();
-             this.windowLocation.search({ breadcrumb: parsedBreadcrumb }).replace();
+             this.windowLocation.search({ 
+                 ...this.parseParamsObject(window.location.search),
+                 breadcrumb: parsedBreadcrumb
+             });
          });
      }
 

--- a/src/breadcrumb_ctrl.ts
+++ b/src/breadcrumb_ctrl.ts
@@ -141,7 +141,8 @@ class BreadcrumbCtrl extends PanelCtrl {
              sessionStorage.setItem("dashlist", JSON.stringify(this.dashboardList));
              // Parse modified breadcrumb and set it to url query params
              const parsedBreadcrumb = this.parseBreadcrumbForUrl();
-             queryParams.breadcrumb = parsedBreadcrumb;
+             const params = this.parseParamsObject(queryParams);
+             params.breadcrumb = parsedBreadcrumb;
              this.windowLocation.search(queryParams);
          });
      }

--- a/src/breadcrumb_ctrl.ts
+++ b/src/breadcrumb_ctrl.ts
@@ -143,7 +143,7 @@ class BreadcrumbCtrl extends PanelCtrl {
              const parsedBreadcrumb = this.parseBreadcrumbForUrl();
              const params = this.parseParamsObject(queryParams);
              params.breadcrumb = parsedBreadcrumb;
-             this.windowLocation.search(queryParams);
+             this.windowLocation.search(params);
          });
      }
 

--- a/src/breadcrumb_ctrl.ts
+++ b/src/breadcrumb_ctrl.ts
@@ -141,10 +141,8 @@ class BreadcrumbCtrl extends PanelCtrl {
              sessionStorage.setItem("dashlist", JSON.stringify(this.dashboardList));
              // Parse modified breadcrumb and set it to url query params
              const parsedBreadcrumb = this.parseBreadcrumbForUrl();
-             this.windowLocation.search({ 
-                 ...this.parseParamsObject(window.location.search),
-                 breadcrumb: parsedBreadcrumb
-             });
+             queryParams.breadcrumb = parsedBreadcrumb;
+             this.windowLocation.search(queryParams);
          });
      }
 


### PR DESCRIPTION
I was helping a friend look at a problem he was experiencing in grafana and I think it might be worth keeping the old query strings around.