### PR TITLE
PULSSI-1399

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Breadcrumb Panel Plugin for Grafana
-This is a panel plugin for [Grafana](http://grafana.org/). It keeps track of dashboards you have visited within one session
-and displays them as a breadcrumb. Each dashboard is added only once to the breadcrumb. You can navigate back to some
-dashboard in breadcrumb by clicking the dashboard name link text. When navigation back all items coming after the selected
-dashboard will be removed from the breadcrumb. Note that breadcrumb can track only dashboards that have breadcrumb panel on them.
+This is a panel plugin for [Grafana](http://grafana.org/). It sends dashboard data to parent frame when page is loaded.
+This way parent frame can keep track of visited dashboards and display them as a breadcrumb. The breadcrumb was previously shown in this Grafana panel but is now moved to Pulssi frontend.
+Note that this plugin can track only dashboards that have breadcrumb panel on them.
 
 To understand what is a plugin, read the [Grafana's documentation about plugins](http://docs.grafana.org/plugins/development/).
 
@@ -23,7 +22,7 @@ The compiled product is in ``dist`` folder.
 Copy the contents of ``dist`` folder to ``plugins/breadcrumb`` folder so Grafana will find the plugin and it can be used in Grafana dashboards.
 
 ### Always inside iFrame
-Pulssi uses Grafana inside iFrame. When breadcrumb panel is loaded it checks if the Grafana window is inside iFrame and if not it is redirected to Pulssi's Grafana page. Also when dashboard is loaded and added to breadcrumb in session storage then this panel sends the updated information to Pulssi frame.
+Pulssi uses Grafana inside iFrame. When breadcrumb panel is loaded it checks if the Grafana window is inside iFrame and if not it is redirected to Pulssi's Grafana page. Also when dashboard is loaded it sends the updated information to Pulssi frame.
 
 ### Navigating out of iFrame
 Sending links from Grafana window to parent window can be achieved by creating a Grafana dashboard link to current dashboard and setting query to contain relaytarget and relayparams parameters.

--- a/src/breadcrumb_ctrl.ts
+++ b/src/breadcrumb_ctrl.ts
@@ -1,19 +1,10 @@
 /**
  * <h3>Breadcrumb panel for Grafana</h3>
  *
- * This breadcumb panel utilizes session storage to store dashboards where user has visited.
- * When panel is loaded it first checks if breadcrumb is given in url params and utilizes that.
- * If no breadcrumb is given in url params then panel tries to read breadcrumb from session storage.
- * Finally the panel adds the just loaded dashboard as the latest item in dashboard and updates session storage.
- * Breadcrumb stores the dashboard's name, url and possible query params to the session storage.
- * If user navigates with browser back button then breadcrumb is recreated from previous url params.
- * Also if user navigates back by clicking one of the breadcrumb items then the items following the selected
- * item are removed from breadcrumb, user is moved to selected dashboard and session storage is updated.
- *
- * Pulssi specific features:
+ * Breadcrumb sends the dashboard's name, url and possible query params to the parent window on page load.
  * Pulssi uses Grafana inside iframe and Grafana shouldn't be used without Pulssi frame.
  * That's why breadcrumb panel checks if it is used inside iframe and if not then it navigates to Pulssi frame.
- * The breadcrumb panel also keeps Pulssi frame in sync with Grafana so that both know the dashboard, breadcrumb
+ * The breadcrumb panel also keeps Pulssi frame in sync with Grafana so that both know the dashboard
  * and Grafana's current url query params. The information is shared with window postmessage.
  * Pulssi breadcrumb also has a feature to navigate out of Grafana frame to some other Pulssi page e.g. Logs.
  * This is done by giving a target url query param in Grafana link e.g. ?relaytarget=logs
@@ -28,25 +19,9 @@ import { impressions } from "app/features/dashboard/impression_store";
 import config from "app/core/config";
 import "./breadcrumb.css!";
 
-export interface IBreadcrumbScope extends ng.IScope {
-    navigate: (url: string) => void;
-}
-
-export interface dashboardListItem {
-    url: string;
-    name: string;
-    params: string;
-    uid: string;
-}
-
-const panelDefaults = {
-    isRootDashboard: false
-};
-
 class BreadcrumbCtrl extends PanelCtrl {
     static templateUrl = "module.html";
     backendSrv: any;
-    dashboardList: dashboardListItem[];
     currentDashboard: string;
     windowLocation: ng.ILocationService;
     panel: any;
@@ -54,34 +29,18 @@ class BreadcrumbCtrl extends PanelCtrl {
 
     /**
      * Breadcrumb class constructor
-     * @param {IBreadcrumbScope} $scope Angular scope
+     * @param {ng.IScope} $scope Angular scope
      * @param {ng.auto.IInjectorService} $injector Angluar injector service
      * @param {ng.ILocationService} $location Angular location service
      * @param {any} backendSrv Grafana backend callback
      */
-    constructor($scope: IBreadcrumbScope, $injector: ng.auto.IInjectorService, $location: ng.ILocationService, backendSrv: any) {
+    constructor($scope: ng.IScope, $injector: ng.auto.IInjectorService, $location: ng.ILocationService,
+      backendSrv: any, $rootScope: ng.IRootScopeService) {
         super($scope, $injector);
-        panelDefaults.isRootDashboard = false;
         this.panel.title = 'Breadcrumb Panel';
-        _.defaults(this.panel, panelDefaults);
-        this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
         // Init variables
-        $scope.navigate = this.navigate.bind(this);
         this.backendSrv = backendSrv;
-        this.dashboardList = [];
         this.windowLocation = $location;
-        // Check for browser session storage and create one if it doesn't exist
-        if (!sessionStorage.getItem("dashlist") || this.panel.isRootDashboard) {
-            sessionStorage.setItem("dashlist", "[]");
-        }
-        // Check if URL params has breadcrumb
-        if ($location.search().breadcrumb) {
-            const items = $location.search().breadcrumb.split(",");
-            this.createDashboardList(items);
-        } else {
-            // If no URL params are given then get dashboard list from session storage
-            this.dashboardList = JSON.parse(sessionStorage.getItem("dashlist"));
-        }
         this.updateText();
         // Check if Grafana is NOT inside Iframe and redirect to Pulssi frame such case
         if (!this.isInsideIframe()) {
@@ -96,7 +55,6 @@ class BreadcrumbCtrl extends PanelCtrl {
             var path = window.location.pathname.split("/");
             this.currentDashboard = path.pop();
             url += "?dashboard=" + path.pop();
-            url += "&breadcrumb=" + this.parseBreadcrumbForUrl()
             const queryParams = window.location.search;
             if (queryParams.indexOf("?") > -1) {
               url += "&" + queryParams.substr(1, queryParams.length)
@@ -109,14 +67,14 @@ class BreadcrumbCtrl extends PanelCtrl {
         // e.g. setting following url-link in some Grafana dashboard: ?relaytarget=logs
         // relayparams-parameter sets the path and possible query-params which are given to iFrame under parent
         // e.g. relaytarget=logs&relayparams=search%3Foption%3Dtest
-        $scope.$on("$routeUpdate", () => {
+        $rootScope.$on("$routeUpdate", () => {
             if ($location.search().relaytarget) {
                 const messageObj = {
                     relaytarget: $location.search().relaytarget,
                     relayparams: $location.search().relayparams
                 };
                 // Add possible url params as their own keys to messageObj
-                if (messageObj.relayparams.indexOf("?") > -1) {
+                if (messageObj.relayparams && messageObj.relayparams.indexOf("?") > -1) {
                     const queryString = messageObj.relayparams.split("?")[1];
                     const queryObj = {};
                     queryString.split("&").map(item => queryObj[item.split("=")[0]] = item.split("=")[1]);
@@ -129,93 +87,12 @@ class BreadcrumbCtrl extends PanelCtrl {
                 window.top.postMessage(messageObj, "*");
             }
         });
-        // Listen for PopState events so we know when user navigates back with browser
-        // On back navigation we'll take the changed breadcrumb param from url query and
-        // recreate dashboard list and notify parent window
-        window.onpopstate = (event: Event) => {
-            if (this.dashboardList.length > 0) {
-                if ($location.state().breadcrumb) {
-                    const items = $location.state().breadcrumb.split(",");
-                    this.createDashboardList(items);
-                }
-                this.notifyContainerWindow();
-            }
-        }
-    }
-
-    /**
-     * Callback for showing panel editor template
-     */
-    onInitEditMode() {
-        this.addEditorTab('Options', 'public/plugins/breadcrumb/editor.html', 2);
-    }
-
-    /**
-     * Create dashboard items
-     * @param {string[]} items Array of dashboard ids
-     */
-    createDashboardList(items: string[]) {
-        if (this.allDashboards) {
-            // Dashboard data has been loaeded from Grafana
-            this.filterDashboardList(items, this.allDashboards);
-        } else {
-            // Fetch list of all dashboards from Grafana
-            this.backendSrv.search().then((result: any) => {
-                this.filterDashboardList(items, result);
-            });
-        }
-    }
-
-    /**
-     * Filter dashboard list
-     * @param {string[]} DBlist Array of dashboards ids to be displayed
-     * @param {any} allDBs All dashboards fetched from Grafana API
-     */
-    filterDashboardList(DBlist: string[], allDBs: any) {
-        var orgId = this.windowLocation.search()["orgId"];
-        this.dashboardList = DBlist.filter((filterItem: string) => {
-            const isInDatabase = _.findIndex(allDBs, (dbItem) => dbItem.url.indexOf(`/d/${filterItem}`) > -1) > -1;
-            return (isInDatabase);
-        })
-        .map((item: string) => {
-            const uid = _.find(allDBs, (dbItem) => dbItem.url.indexOf(`/d/${item}`) > -1).uid;
-            return {
-                url: `/d/${uid}`,
-                name: _.find(allDBs, (dbItem) => dbItem.url.indexOf(`/d/${item}`) > -1).title,
-                params: this.parseParamsString({ orgId }),
-                uid
-            }
-        });
-        // Update session storage
-        sessionStorage.setItem("dashlist", JSON.stringify(this.dashboardList));
-    }
-
-    /**
-     * Parse breadcrumb string for URL
-     * @returns {string}
-     */
-    parseBreadcrumbForUrl() {
-        let parsedBreadcrumb = "";
-        this.dashboardList.map((item, index) => {
-            parsedBreadcrumb += item.url.split("/").pop();
-            if (index < this.dashboardList.length - 1) {
-                parsedBreadcrumb += ",";
-            }
-        });
-        return parsedBreadcrumb;
     }
 
     /**
      * Update Breadcrumb items
      */
     updateText() {
-        // Get Grafana query params
-        let grafanaQueryParams = "";
-        Object.keys(this.windowLocation.search()).map((param) => {
-            if (this.windowLocation.search()[param] && this.windowLocation.search()[param] !== "null") {
-                grafanaQueryParams += "&" + param + "=" + this.windowLocation.search()[param];
-            }
-        });
         // Fetch list of all dashboards from Grafana
         this.backendSrv.search().then((result: any) => {
             this.allDashboards = result;
@@ -225,114 +102,29 @@ class BreadcrumbCtrl extends PanelCtrl {
             const dbSource = "/d/" + path.pop();
             const uri = `${dbSource}`;
             var obj: any = _.find(result, (dbItem) => dbItem.url.indexOf(`${uri}`) > -1);
-            // Add current dashboard to breadcrumb if it doesn't exist
-            if (_.findIndex(this.dashboardList, (dbItem) => dbItem.url.indexOf(`${uri}`) > -1) < 0 && obj) {
-                this.dashboardList.push( { url: uri, name: obj.title, params: grafanaQueryParams, uid: obj.uid } );
-            }
-            // Update session storage
-            sessionStorage.setItem("dashlist", JSON.stringify(this.dashboardList));
-            this.notifyContainerWindow();
-            // Parse modified breadcrumb and set it to url query params
-            const parsedBreadcrumb = this.parseBreadcrumbForUrl();
-            const queryObject = this.parseParamsObject(grafanaQueryParams);
-            queryObject["breadcrumb"] = parsedBreadcrumb;
-            this.windowLocation.state(queryObject).replace();
-            history.replaceState(queryObject, "");
+            this.notifyContainerWindow({ url: uri, name: obj.title, uid: obj.uid });
         });
     }
 
     /**
      * Notify container window
      */
-    notifyContainerWindow() {
+    notifyContainerWindow(messageObj: any) {
         // Get Grafana query params
         let grafanaQueryParams = "";
+        let orgId = "";
         Object.keys(this.windowLocation.search()).map((param) => {
             if (param !== "breadcrumb" && param !== "dashboard" && param !== "orgId" && param !== "random"
                 && this.windowLocation.search()[param] && this.windowLocation.search()[param] !== "null") {
                 grafanaQueryParams += "&" + param + "=" + this.windowLocation.search()[param];
+            } if (param === "orgId") {
+                orgId = this.windowLocation.search()[param];
             }
         });
-        // Check organisation id
-        this.backendSrv.get("api/org").then((result: any) => {
-            const orgId = String(result.id);
-            var path = window.location.pathname.split("/");
-            this.currentDashboard = path.pop();
-            const messageObj = {
-                dashboard: path.pop(),
-                breadcrumb: this.dashboardList,
-                orgId,
-                grafanaQueryParams
-            }
-            // Send message to upper window
-            window.top.postMessage(messageObj, "*");
-        });
-    }
-
-    /**
-     * Parse params string to object
-     * @param {string} params
-     * @returns {Object}
-     */
-    parseParamsObject(params: string) {
-        const paramsObj = {};
-        if (params.charAt(0) === "?" || params.charAt(0) === "&") {
-            params = params.substr(1, params.length);
-        }
-        const paramsArray = params.split("&");
-        paramsArray.map((paramItem) => {
-            const paramItemArr = paramItem.split("=");
-            paramsObj[paramItemArr[0]] = paramItemArr[1];
-        });
-        return paramsObj;
-    }
-
-    /**
-     * Parse params object to string
-     * @param {Object} params
-     * @returns {string}
-     */
-    parseParamsString(params: Object) {
-        let paramsString = "?";
-        Object.keys(params).map((paramKey, index) => {
-            paramsString += paramKey + "=" + params[paramKey];
-            if (index < Object.keys(params).length - 1) {
-                paramsString += "&";
-            }
-        });
-        return paramsString;
-    }
-
-    /**
-     * Navigate to given dashboard
-     * @param {string} url
-     */
-    navigate(url: string, params: string) {
-        // Check if user is navigating backwards in breadcrumb and
-        // remove all items that follow the selected item in that case
-        const index = _.findIndex(this.dashboardList, (dbItem) => dbItem.url.indexOf(`${url}`) > -1);
-        if (index > -1 && this.dashboardList.length >= index + 2) {
-            this.dashboardList.splice(index + 1, this.dashboardList.length - index - 1);
-            sessionStorage.setItem("dashlist", JSON.stringify(this.dashboardList));
-        }
-        // Parse params string to object
-        const queryParams = this.parseParamsObject(params);
-        // Delete possible breadcrumb param so that breadcrumb from session will be used instead
-        delete queryParams["breadcrumb"];
-        let urlRoot = "";
-        if (window.location.hostname === "localhost") {
-            // Using local version of Grafana for testing purposes
-            urlRoot = "http://localhost:3000";
-        } else {
-            // Assume that Grafana is in folder path 'grafana'
-            urlRoot = window.location.protocol + "//" + window.location.hostname + "/grafana";
-        }
-        if (url.charAt(0) != "/") {
-            urlRoot += "/";
-        }
-        // Set new url and notify parent window
-        window.location.href = urlRoot + url + this.parseParamsString(queryParams);
-        this.notifyContainerWindow();
+        messageObj.breadcrumb = true;
+        messageObj.params = grafanaQueryParams;
+        messageObj.orgId = orgId;
+        window.top.postMessage(messageObj, "*");
     }
 
     /**

--- a/src/editor.pug
+++ b/src/editor.pug
@@ -1,5 +1,0 @@
-div.editor-row
-  div.section.gf-form-group
-    h5.section-heading Breadcrumb Panel Options
-    div.gf-form
-      gf-form-switch(label="Is Root Dashboard" checked="ctrl.panel.isRootDashboard" label-class="width-7").gf-form

--- a/src/module.pug
+++ b/src/module.pug
@@ -1,9 +1,3 @@
 div
-  ol.breadcrumb-panel(ng-hide="ctrl.dashboardList.length == 1 && ctrl.dashboardList[0].url.indexOf(ctrl.currentDashboard) > -1")
-    li(ng-repeat="dashboard in ctrl.dashboardList track by $index")
-      a(href="#" ng-click="navigate(dashboard.url, dashboard.params)") {{ dashboard.name }}
-      svg(height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg")
-        path(d="M3.1,0L1.9,1.2L5.7,5L1.9,8.8L3.1,10l5-5L3.1,0z")
-        path(d="M-7-7h24v24H-7V-7z" fill="none")
-  ol.breadcrumb-panel(ng-show="ctrl.dashboardList.length == 1 && ctrl.dashboardList[0].url.indexOf(ctrl.currentDashboard) > -1")
+  ol.breadcrumb-panel
     li &nbsp;


### PR DESCRIPTION
- Created a new 2.0 branch for breadcrumb
- Much of the functionality is now moved to Pulssi frontend
- Grafana plugin is still needed to redirect user to Pulssi-frame if Grafana dashboard is being opened directly
- Also the tracking of which dashboard was opened is easier when Grafana sends the message; It seems that tracking route changes inside iFrame is difficult since it doesn't send onLoad events on that case.